### PR TITLE
Corrección del color de fondo en iconos

### DIFF
--- a/fc-material.user.css
+++ b/fc-material.user.css
@@ -274,6 +274,14 @@
             background: #f2f26d !important;
         }
 
+        div#vB_Editor_QR_controls * {
+            background-color: transparent !important;
+        }
+
+        div#vB_Editor_001_controls .imagebutton{
+            background-color: transparent !important;
+        }
+
         /* fin parametros tema oscuro */
 
     }


### PR DESCRIPTION
En el tema oscuro, tras hacer hover, los iconos tenían un fondo blanco que los ocultaba en la barra de acciones rápidas en respuesta tanto en el modo rápido como avanzado.